### PR TITLE
Testfix

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,4 +9,16 @@ module.exports = {
   moduleNameMapper: {
     "~/(.*)": ["<rootDir>/src/$1"],
   },
+  coveragePathIgnorePatterns: [
+    "node_modules",
+    "test-config",
+    "interfaces",
+    "jestGlobalMocks.ts",
+    ".module.ts",
+    "<rootDir>/src/utils/session.ts",
+    "<rootDir>/src/server/api/trpc.ts",
+    "<rootDir>/src/server/api/trpc.ts",
+
+    // ".mock.ts",
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postinstall": "prisma generate",
     "lint": "next lint",
     "start": "next start",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.1.1",

--- a/src/server/api/routers/auth.ts
+++ b/src/server/api/routers/auth.ts
@@ -25,7 +25,7 @@ export const authRouter = createTRPCRouter({
       const { prisma } = ctx;
       const { username, password } = input;
 
-      const existingUser = await prisma.user.findUnique({
+      const existingUser = await ctx.prisma.user.findUnique({
         where: {
           username: username,
         },
@@ -42,7 +42,7 @@ export const authRouter = createTRPCRouter({
 
       // console.log("HASHED", hashedPassword);
 
-      const result = await prisma.user.create({
+      const result = await ctx.prisma.user.create({
         data: {
           username,
           password: hashedPassword,
@@ -69,7 +69,7 @@ export const authRouter = createTRPCRouter({
     const { prisma } = ctx;
     const { username, password } = input;
 
-    const existingUser = await prisma.user.findUnique({
+    const existingUser = await ctx.prisma.user.findUnique({
       where: {
         username: username,
       },
@@ -98,7 +98,7 @@ export const authRouter = createTRPCRouter({
     const sessionexpires = fromDate(sessionMaxAge);
     // add the session to the db
 
-    const createSession = await prisma.session.create({
+    const createSession = await ctx.prisma.session.create({
       data: {
         expires: sessionexpires,
         sessionToken: sessionToken,
@@ -145,9 +145,7 @@ export const authRouter = createTRPCRouter({
       };
     }
 
-    const { prisma } = ctx;
-
-    await prisma.session.delete({
+    await ctx.prisma.session.delete({
       where: {
         sessionToken: ctx.session.sessionToken,
       },

--- a/src/server/api/routers/quote.ts
+++ b/src/server/api/routers/quote.ts
@@ -33,7 +33,7 @@ export const quoteRouter = createTRPCRouter({
         },
       });
 
-      console.log("QUOTE", quote);
+      // console.log("QUOTE", quote);
 
       if (!quote) {
         throw new TRPCError({

--- a/src/server/api/routers/quote.ts
+++ b/src/server/api/routers/quote.ts
@@ -1,7 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { newQuoteSchema } from "~/pages/newquote/newquoteSchema";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
-import { prisma } from "~/server/db";
 
 export const quoteRouter = createTRPCRouter({
   getPricePerGallon: protectedProcedure
@@ -24,18 +23,19 @@ export const quoteRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const { gallonsRequested, deliveryDate, pricePerGallon, total } = input;
 
-      try {
-        await prisma.quote.create({
-          data: {
-            userId: ctx.session.User.id,
-            deliveryDate: deliveryDate,
-            gallonsRequested: gallonsRequested,
-            pricePerGallon: pricePerGallon,
-            total: total,
-          },
-        });
-      } catch (e) {
-        console.log(e);
+      const quote = await ctx.prisma.quote.create({
+        data: {
+          userId: ctx.session.User.id,
+          deliveryDate: deliveryDate,
+          gallonsRequested: gallonsRequested,
+          pricePerGallon: pricePerGallon,
+          total: total,
+        },
+      });
+
+      console.log("QUOTE", quote);
+
+      if (!quote) {
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Something went wrong!",

--- a/src/server/tests/auth.test.ts
+++ b/src/server/tests/auth.test.ts
@@ -1,35 +1,21 @@
-import type { IncomingMessage, ServerResponse } from "http";
-import { type AppRouter, appRouter } from "../api/root";
-import type { inferProcedureInput } from "@trpc/server";
-import { createInnerTRPCContext } from "../api/trpc";
-import { prisma } from "../db";
+import { type AppRouter } from "../api/root";
+import { TRPCError, type inferProcedureInput } from "@trpc/server";
+import { createTestContext } from "./testingConfig";
+import { hash } from "argon2";
 
-afterAll(async () => {
-  await prisma.user.deleteMany();
-});
-
-describe("AUTH API", () => {
+describe("AUTH API SIGNUP PROC", () => {
   test("[AUTH API]: signup", async () => {
-    const req = {} as IncomingMessage; // fake request object
-    const res = {} as ServerResponse; // fake request object
-
-    const ctx = createInnerTRPCContext({
+    const { caller, prismaMock } = createTestContext({
       session: null,
-      req: req,
-      res: res,
     });
 
-    const caller = appRouter.createCaller(ctx);
-
-    try {
-      await prisma.user.delete({
-        where: {
-          username: "TEST_USERNAME",
-        },
-      });
-    } catch (e) {
-      console.log(e);
-    }
+    prismaMock.user.create.mockResolvedValue({
+      id: "TEST_USER_ID",
+      username: "TEST_USERNAME",
+      password: "TEST_PASSWORD",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
 
     type Input = inferProcedureInput<AppRouter["auth"]["signUp"]>;
     const input: Input = {
@@ -43,6 +29,191 @@ describe("AUTH API", () => {
       status: "success",
       message: "User created",
       result: input.username,
+    });
+  });
+
+  it("signup should fail if a user with the same username already exists", async () => {
+    const { prismaMock, caller } = createTestContext({
+      session: null,
+    });
+
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "TEST_USER_ID",
+      username: "TEST_USERNAMEeee",
+      password: "TEST_PASSWORD",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    type Input = inferProcedureInput<AppRouter["auth"]["signUp"]>;
+    const input: Input = {
+      username: "TEST_USERNAMEeee",
+      password: "TEST_PASSWORD",
+    };
+
+    await expect(caller.auth.signUp(input)).rejects.toThrowError(
+      new TRPCError({
+        code: "FORBIDDEN",
+        message: "Username already in use",
+      })
+    );
+  });
+
+  it("signup should fail if the prisma client throws an error", async () => {
+    const { prismaMock, caller } = createTestContext({
+      session: null,
+    });
+
+    prismaMock.user.create.mockRejectedValue(null);
+
+    type Input = inferProcedureInput<AppRouter["auth"]["signUp"]>;
+    const input: Input = {
+      username: "TEST_USERNAME",
+      password: "TEST_PASSWORD",
+    };
+
+    await expect(caller.auth.signUp(input)).rejects.toThrowError(
+      new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "INTERNAL_SERVER_ERROR",
+      })
+    );
+  });
+});
+
+describe("AUTH API LOGIN PROC", () => {
+  it("login should fail if the user does not exist", async () => {
+    const { prismaMock, caller } = createTestContext({
+      session: null,
+    });
+
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    type Input = inferProcedureInput<AppRouter["auth"]["login"]>;
+    const input: Input = {
+      username: "TEST_USERNAME",
+      password: "TEST_PASSWORD",
+    };
+
+    await expect(caller.auth.login(input)).rejects.toThrowError(
+      new TRPCError({
+        code: "UNAUTHORIZED",
+        message: "User Not Found",
+      })
+    );
+  });
+
+  it("login should fail if the password is incorrect", async () => {
+    const { prismaMock, caller } = createTestContext({
+      session: null,
+    });
+
+    const hashedPassword = await hash("TEST_PASSWORD");
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "TEST_USER_ID",
+      username: "TEST_USERNAME",
+      password: hashedPassword,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    type Input = inferProcedureInput<AppRouter["auth"]["login"]>;
+    const input: Input = {
+      username: "TEST_USERNAME",
+      password: "TEST_PASSWORD_WRONG",
+    };
+
+    await expect(caller.auth.login(input)).rejects.toThrowError(
+      new TRPCError({
+        code: "UNAUTHORIZED",
+        message: "Invalid credentials",
+      })
+    );
+  });
+
+  it("login should fail if the prisma client throws an error", async () => {
+    const { prismaMock, caller } = createTestContext({
+      session: null,
+    });
+
+    prismaMock.user.findUnique.mockRejectedValue(null);
+
+    type Input = inferProcedureInput<AppRouter["auth"]["login"]>;
+    const input: Input = {
+      username: "TEST_USERNAME",
+      password: "TEST_PASSWORD",
+    };
+
+    await expect(caller.auth.login(input)).rejects.toThrowError(
+      new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "INTERNAL_SERVER_ERROR",
+      })
+    );
+  });
+
+  it("login should succeed if the user exists and the password is correct", async () => {
+    const { prismaMock, caller } = createTestContext({
+      session: null,
+    });
+
+    const hashedPassword = await hash("TEST_PASSWORD");
+
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "TEST_USER_ID",
+      username: "TEST_USERNAME",
+      password: hashedPassword,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    prismaMock.session.create.mockResolvedValue({
+      id: "TEST_SESSION_ID",
+      sessionToken: "TEST_SESSION_ID",
+      userId: "TEST_USER_ID",
+      expires: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    type Input = inferProcedureInput<AppRouter["auth"]["login"]>;
+    const input: Input = {
+      username: "TEST_USERNAME",
+      password: "TEST_PASSWORD",
+    };
+
+    const result = await caller.auth.login(input);
+
+    expect(result).toStrictEqual({
+      status: "success",
+      message: "User logged in",
+    });
+  });
+});
+
+describe("AUTH GET SESSION PROC", () => {
+  it("getSession should fail if the user is not logged in", async () => {
+    const { caller } = createTestContext({
+      session: null,
+    });
+
+    const result = await caller.auth.getSession();
+
+    expect(result).toBe(null);
+  });
+
+  it("getSession should succeed if the user is logged in", async () => {
+    const { caller, sessionExpires } = createTestContext({
+      session: true,
+    });
+
+    const result = await caller.auth.getSession();
+    // might fail because of date comparison??
+    expect(result).toStrictEqual({
+      User: { id: "TEST_USER_ID", username: "TEST_USERNAME" },
+      expires: sessionExpires,
+      id: "TEST_USER_ID",
+      sessionToken: "TEST_SESSION_TOKEN",
     });
   });
 });

--- a/src/server/tests/profile.test.ts
+++ b/src/server/tests/profile.test.ts
@@ -8,9 +8,9 @@ import { mockDeep } from "jest-mock-extended";
 import type { PrismaClient } from "@prisma/client";
 import { prisma } from "../db";
 
-afterAll(async () => {
-  await prisma.user.deleteMany();
-});
+// afterAll(async () => {
+//   await prisma.user.deleteMany();
+// });
 
 describe("PROFILE API TEST", () => {
   test("[PROFILE API]: createProfile", async () => {

--- a/src/server/tests/quotehistory.test.ts
+++ b/src/server/tests/quotehistory.test.ts
@@ -1,26 +1,11 @@
-import type { IncomingMessage, ServerResponse } from "http";
-import { appRouter } from "../api/root";
-import { type ServerSession } from "../auth";
-import { type PrismaClient, type Quote } from "@prisma/client";
-import { Decimal } from "@prisma/client/runtime";
-import { mockDeep } from "jest-mock-extended";
+import { createTestContext } from "./testingConfig";
+import { Prisma, type Quote } from "@prisma/client";
 
 describe("quotehistory", () => {
   test("hello test", async () => {
-    const req = {} as IncomingMessage; // fake request object
-    const res = {} as ServerResponse; // fake request object
-
-    const mockSession: ServerSession = {
-      expires: new Date(),
-      id: "TEST_SESSION_ID",
-      sessionToken: "TEST_SESSION_TOKEN",
-      User: {
-        id: "TEST_USER_ID",
-        username: "TEST_USERNAME",
-      },
-    };
-
-    const prismaMock = mockDeep<PrismaClient>();
+    const { caller, prismaMock } = createTestContext({
+      session: true,
+    });
 
     const mockOutput: Quote[] = [
       {
@@ -29,18 +14,11 @@ describe("quotehistory", () => {
         updatedAt: new Date(),
         userId: "TEST_USER_ID",
         deliveryDate: new Date(),
-        gallonsRequested: new Decimal(1),
-        pricePerGallon: new Decimal(1),
-        total: new Decimal(1),
+        gallonsRequested: new Prisma.Decimal(1),
+        pricePerGallon: new Prisma.Decimal(1),
+        total: new Prisma.Decimal(1),
       },
     ];
-
-    const caller = appRouter.createCaller({
-      session: mockSession,
-      prisma: prismaMock,
-      req: req,
-      res: res,
-    });
 
     prismaMock.quote.findMany.mockResolvedValue(mockOutput);
 

--- a/src/server/tests/testingConfig.ts
+++ b/src/server/tests/testingConfig.ts
@@ -1,0 +1,56 @@
+import type { IncomingMessage, ServerResponse } from "http";
+import { type AppRouter, appRouter } from "../api/root";
+import { createInnerTRPCContext } from "../api/trpc";
+import { type ServerSession } from "../auth";
+import { type DeepMockProxy, mockDeep } from "jest-mock-extended";
+import { type Prisma, type PrismaClient } from "@prisma/client";
+
+export interface TestContext {
+  caller: ReturnType<AppRouter["createCaller"]>;
+  prismaMock: DeepMockProxy<
+    PrismaClient<
+      Prisma.PrismaClientOptions,
+      never,
+      Prisma.RejectOnNotFound | Prisma.RejectPerOperation | undefined
+    >
+  >;
+  sessionExpires: Date;
+}
+
+export function createTestContext({
+  session = null,
+  req = {} as IncomingMessage,
+  res = {} as ServerResponse,
+}: {
+  session?: ServerSession | null | boolean;
+  req?: IncomingMessage;
+  res?: ServerResponse;
+}): TestContext {
+  const prismaMock = mockDeep<PrismaClient>();
+
+  const sessionExpires = new Date();
+  const mockSession: ServerSession = {
+    expires: sessionExpires,
+    id: "TEST_USER_ID",
+    sessionToken: "TEST_SESSION_TOKEN",
+    User: {
+      id: "TEST_USER_ID",
+      username: "TEST_USERNAME",
+    },
+  };
+
+  const ctx = createInnerTRPCContext({
+    session: session === true ? mockSession : null,
+    req,
+    res,
+    prisma: prismaMock,
+  });
+
+  const caller = appRouter.createCaller(ctx);
+
+  return {
+    caller,
+    prismaMock,
+    sessionExpires,
+  };
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -2,6 +2,7 @@ import { type CreateHTTPContextOptions } from "@trpc/server/adapters/standalone"
 import { type ServerSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 
+/* istanbul ignore next */
 export const getServerAuthSession = async (ctx: {
   req: CreateHTTPContextOptions["req"];
   res: CreateHTTPContextOptions["res"];
@@ -29,7 +30,7 @@ export const getServerAuthSession = async (ctx: {
           User: {
             id: user.id,
             username: user.username,
-          }
+          },
         };
       }
     }
@@ -37,6 +38,7 @@ export const getServerAuthSession = async (ctx: {
   return null;
 };
 
+/* istanbul ignore next */
 export const validateSession = async (rawSessionCookie: string) => {
   const session = await prisma.session.findUnique({
     where: {


### PR DESCRIPTION
removed the afterAll delete user because for some reason it was effecting the actual application when running the app. added the testConfig.ts to have a consistent ctx file to pass and use prismaMock and session. if you want to use session in the ctx (like the user is authorized) use `session: true` in 
```typescript 
createTestContext({
    session: null,
});
``` 
is default